### PR TITLE
Support pipeline

### DIFF
--- a/src/MockPredisConnection.php
+++ b/src/MockPredisConnection.php
@@ -12,6 +12,18 @@ use Illuminate\Redis\Connections\PredisConnection;
 
 class MockPredisConnection extends PredisConnection
 {
+    /**
+     * Execute commands in a pipeline.
+     *
+     * @param  callable|null  $callback
+     * @return \Redis|array
+     */
+    public function pipeline(callable $callback = null)
+    {
+        $pipeline = $this->client()->pipeline();
 
-
+        return is_null($callback)
+            ? $pipeline
+            : tap($pipeline, $callback)->exec();
+    }
 }

--- a/tests/RedisMockTest.php
+++ b/tests/RedisMockTest.php
@@ -26,6 +26,18 @@ class RedisMockTest extends TestCase
 
     }
 
+    public function testPipeline() {
+
+        $this->assertInstanceOf(MockPredisConnection::class, Redis::connection());
+
+        Redis::pipeline(function ($pipe) {
+            $pipe->set('key1', 'test1');
+            $pipe->set('key2', 'test2');
+        });
+
+        $this->assertEquals('test2', Redis::get('key2'));
+    }
+
 }
 
 


### PR DESCRIPTION
This makes `pipeline()` work. 

`MockPredisConnection` extends `PredisConnection` which in turn provided `pipeline` functionality. 
However, `PredisConnection` seems to take care of closing the pipeline by itself whereas `RedisMock` doesn't. So, I've added the `pipeline` method to the `MockPredisConnection` to take care of closing the `Pipeline`. 