### PR TITLE
Fix implicit nullable deprecation

### DIFF
--- a/src/MockPredisConnection.php
+++ b/src/MockPredisConnection.php
@@ -19,7 +19,7 @@ class MockPredisConnection extends PredisConnection
      *
      * @return \Redis|array
      */
-    public function pipeline(callable $callback = null)
+    public function pipeline(?callable $callback = null)
     {
         $pipeline = $this->client()->pipeline();
 


### PR DESCRIPTION
The deprecation in later PHP versions for implicit nullability is failing tests that assert logs, but require this mocked redis connector. This fixes said deprecation.